### PR TITLE
Fix fw_rule_v2 update error

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_fw_rule_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_fw_rule_v2.go
@@ -171,32 +171,50 @@ func resourceFWRuleV2Update(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating OpenTelekomCloud networking client: %s", err)
 	}
 
-	name := d.Get("name").(string)
-	description := d.Get("description").(string)
-	protocol := d.Get("protocol").(string)
-	action := d.Get("action").(string)
-	ipVersion := resourceFWRuleV2DetermineIPVersion(d.Get("ip_version").(int))
-	sourceIPAddress := d.Get("source_ip_address").(string)
-	sourcePort := d.Get("source_port").(string)
-	destinationIPAddress := d.Get("destination_ip_address").(string)
-	destinationPort := d.Get("destination_port").(string)
-	enabled := d.Get("enabled").(bool)
-
-	opts := rules.UpdateOpts{
-		Name:                 &name,
-		Description:          &description,
-		Protocol:             &protocol,
-		Action:               &action,
-		IPVersion:            &ipVersion,
-		SourceIPAddress:      &sourceIPAddress,
-		DestinationIPAddress: &destinationIPAddress,
-		SourcePort:           &sourcePort,
-		DestinationPort:      &destinationPort,
-		Enabled:              &enabled,
+	var updateOpts rules.UpdateOpts
+	if d.HasChange("name") {
+		name := d.Get("name").(string)
+		updateOpts.Name = &name
+	}
+	if d.HasChange("description") {
+		description := d.Get("description").(string)
+		updateOpts.Description = &description
+	}
+	if d.HasChange("protocol") {
+		protocol := d.Get("protocol").(string)
+		updateOpts.Protocol = &protocol
+	}
+	if d.HasChange("action") {
+		action := d.Get("action").(string)
+		updateOpts.Action = &action
+	}
+	if d.HasChange("ip_version") {
+		ipVersion := resourceFWRuleV2DetermineIPVersion(d.Get("ip_version").(int))
+		updateOpts.IPVersion = &ipVersion
+	}
+	if d.HasChange("source_ip_address") {
+		sourceIPAddress := d.Get("source_ip_address").(string)
+		updateOpts.SourceIPAddress = &sourceIPAddress
+	}
+	if d.HasChange("source_port") {
+		sourcePort := d.Get("source_port").(string)
+		updateOpts.SourcePort = &sourcePort
+	}
+	if d.HasChange("destination_ip_address") {
+		destinationIPAddress := d.Get("destination_ip_address").(string)
+		updateOpts.DestinationIPAddress = &destinationIPAddress
+	}
+	if d.HasChange("destination_port") {
+		destinationPort := d.Get("destination_port").(string)
+		updateOpts.DestinationPort = &destinationPort
+	}
+	if d.HasChange("enabled") {
+		enabled := d.Get("enabled").(bool)
+		updateOpts.Enabled = &enabled
 	}
 
-	log.Printf("[DEBUG] Updating firewall rules: %#v", opts)
-	err = rules.Update(networkingClient, d.Id(), opts).Err
+	log.Printf("[DEBUG] Updating firewall rules: %#v", updateOpts)
+	err = rules.Update(networkingClient, d.Id(), updateOpts).Err
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR tries to fix firewall rule update error.

I'm getting an error when only updating fw rule name.
Terraform configuration files
```
resource "opentelekomcloud_fw_rule_v2" "rule_1" {
  name             = "terraform_rule-1"
  description      = "drop TELNET traffic"
  action           = "deny"
  protocol         = "tcp"
  destination_port = "24"
  enabled          = "true"
}
```
After changing the name to "terraform_rule-1-update", I got an error as below

```
"NeutronError": {
  "detail": "",
  "message": "Invalid input for source_port. Reason: Port '' is not a valid number.",
  "type": "HTTPBadRequest"
}
```

The reason of this is because we send all fields with the request body regardless of whether it's changed or not. And uses "" for unchanged fields instead of null which is the root cause.

```
"firewall_rule": {
    "action": "deny",
    "description": "drop TELNET traffic",
    "destination_ip_address": "",
    "destination_port": "24",
    "enabled": true,
    "ip_version": 4,
    "name": "terraform_rule-1-update-two1",
    "protocol": "tcp",
    "source_ip_address": "",
    "source_port": ""
}
```