### PR TITLE
Add schedule hint support in volume resource

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_blockstorage_volume_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_blockstorage_volume_v2.go
@@ -100,7 +100,7 @@ func resourceBlockStorageVolumeV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 			},
-			"schedule_hint": &schema.Schema{
+			"scheduler_hints": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
 			},
@@ -137,9 +137,9 @@ func resourceContainerMetadataV2(d *schema.ResourceData) map[string]string {
 	return m
 }
 
-func resourceScheduleHint(d *schema.ResourceData) map[string]string {
+func resourceSchedulerHints(d *schema.ResourceData) map[string]string {
 	hint := make(map[string]string)
-	for key, val := range d.Get("schedule_hint").(map[string]interface{}) {
+	for key, val := range d.Get("scheduler_hints").(map[string]interface{}) {
 		hint[key] = val.(string)
 	}
 	return hint
@@ -187,7 +187,7 @@ func resourceBlockStorageVolumeV2Create(d *schema.ResourceData, meta interface{}
 		SourceReplica:      d.Get("source_replica").(string),
 		SourceVolID:        d.Get("source_vol_id").(string),
 		VolumeType:         d.Get("volume_type").(string),
-		ScheduleHint:       resourceScheduleHint(d),
+		SchedulerHints:     resourceSchedulerHints(d),
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)

--- a/opentelekomcloud/resource_opentelekomcloud_blockstorage_volume_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_blockstorage_volume_v2.go
@@ -100,6 +100,10 @@ func resourceBlockStorageVolumeV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 			},
+			"schedule_hint": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
 			"attachment": &schema.Schema{
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -131,6 +135,14 @@ func resourceContainerMetadataV2(d *schema.ResourceData) map[string]string {
 		m[key] = val.(string)
 	}
 	return m
+}
+
+func resourceScheduleHint(d *schema.ResourceData) map[string]string {
+	hint := make(map[string]string)
+	for key, val := range d.Get("schedule_hint").(map[string]interface{}) {
+		hint[key] = val.(string)
+	}
+	return hint
 }
 
 func resourceContainerTags(d *schema.ResourceData) map[string]string {
@@ -175,6 +187,7 @@ func resourceBlockStorageVolumeV2Create(d *schema.ResourceData, meta interface{}
 		SourceReplica:      d.Get("source_replica").(string),
 		SourceVolID:        d.Get("source_vol_id").(string),
 		VolumeType:         d.Get("volume_type").(string),
+		ScheduleHint:       resourceScheduleHint(d),
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)


### PR DESCRIPTION
### Use Case
The OpenStack cinder supports to add schedule parameters when creating 
volume, the name of the parameters in API doc is "OS-SCH-HNT:scheduler_hints" 
that can be found in Cinder API document [here](https://developer.openstack.org/api-ref/block-storage/v3/index.html#volumes-volumes)
In some cases, the user wish to set the parameters to fix the volume location.
this PR is to propose to add this parameter support in otc provider.

### Propose To Change
In order to support this paramter, these parties need to change:
1. Add the parameter support in Gophercloud SDKs
2. Add the configuration parameter in provider
3. Add the parameter vonverting when volume creation.

#1. please review https://github.com/gator1/gophercloud/pull/8
#2 #3 are here.

### Impact Anlysis
All configurations that end users had will work as they did.
Only to add following parties when the scenario need this party

>resource "opentelekomcloud_blockstorage_volume_v2" "volume_fe01_01" {
>  name        = "lizhonghua_test"
>  size        = 10
>  availability_zone = "eu-de-01"
>  **schedule_hint  {
>    HOST = "cinder-kvm001@SATA#0"
>  }**
>}

This addition will not impact other resources as it is only a single
addition for volume creation.


### Acceptance Test
All tests related this part passed, the log as follow:
=== RUN   TestAccBlockStorageV2Volume_importBasic
--- PASS: TestAccBlockStorageV2Volume_importBasic (53.72s)
=== RUN   TestAccBlockStorageV2Volume_basic
--- PASS: TestAccBlockStorageV2Volume_basic (164.38s)
=== RUN   TestAccBlockStorageV2Volume_tags
--- PASS: TestAccBlockStorageV2Volume_tags (97.94s)
=== RUN   TestAccBlockStorageV2Volume_image
--- PASS: TestAccBlockStorageV2Volume_image (211.33s)
=== RUN   TestAccBlockStorageV2Volume_timeout
--- PASS: TestAccBlockStorageV2Volume_timeout (163.62s)


Resolves : #23