### PR TITLE
Fix the error about the rds instance acc test

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_rds_instance_v1.go
+++ b/opentelekomcloud/resource_opentelekomcloud_rds_instance_v1.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/rds/v1/instances"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"strings"
 	"time"
 )
 
@@ -375,7 +376,14 @@ func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Retrieved instance %s: %#v", instanceID, instance)
 
-	d.Set("name", instance.Name)
+	if instance.Name != "" {
+		nameList := strings.Split(instance.Name, "-"+instance.DataStore.Type)
+		log.Printf("[DEBUG] Retrieved nameList %#v", nameList)
+		if len(nameList) > 0 {
+			d.Set("name", nameList[0])
+		}
+	}
+
 	d.Set("hostname", instance.HostName)
 	d.Set("type", instance.Type)
 	d.Set("region", instance.Region)


### PR DESCRIPTION
Fix the error about the rds instance acc test
The reason is that the name of rds instance in the response is different.

The rds instance  acc test result and log:
http://paste.openstack.org/show/652080/
