### PR TITLE
Integrate the OpenLab CI system to telekom provider repo

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,4 @@
+- project:
+    check-generic-cloud:
+      jobs:
+        - terraform-provider-opentelekomcloud-acceptance-test-telekom


### PR DESCRIPTION
This change want to support the OpenLab CI system with opentelekomcloud
provider repo. The CI job will running the acceptance tests of this
provider against a telekom cloud environment.

To trigger this job, please comment "recheck" under a PR.

- The telekom CI job definition: # theopenlab/openlab-zuul-jobs/pull/36
- The PR to test the job: #  liu-sheng/terraform-provider-opentelekomcloud/pull/1