### PR TITLE
Fix the error about deleting the rds instacne

### DIFF
--- a/vendor/github.com/gophercloud/gophercloud/openstack/rds/v1/instances/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/rds/v1/instances/requests.go
@@ -179,9 +179,10 @@ func UpdateFlavorRef(client *gophercloud.ServiceClient, ops UpdateFlavorOpsBuild
 func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	RequestOpts.OkCodes = []int{202}
 	RequestOpts.JSONBody = nil
+	JSONBody := make(map[string]interface{})
 	_, r.Err = client.Delete(deleteURL(client, id), &gophercloud.RequestOpts{
 		OkCodes:     []int{202},
-		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
+		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: JSONBody,
 	})
 	return
 }


### PR DESCRIPTION
In the newest version of OTC rds services, the rds instance only can be deleted with a request body: {}.
This pr fix this error.
The test result about deleting the rds instance in the OTC :
http://paste.openstack.org/show/666932/